### PR TITLE
Fix apt-key warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM jenkinsci/ssh-slave
 
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
 RUN echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" >> /etc/apt/sources.list && \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 && \
 	apt-get update && \


### PR DESCRIPTION
The "warning" broke the build process. Workaround from
https://github.com/ansible/ansible/issues/28820