### PR TITLE
Use newer Ansible version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 RUN echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" >> /etc/apt/sources.list && \
 	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 93C4A3FD7BB9C367 && \
 	apt-get update && \
-	apt-get install -y ansible=2.5\*
+	apt-get install -y --no-install-recommends ansible=2.7\* && \
+	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The PPA no longer contains version 2.5, causing the Dockerfile build to
fail. Updated to 2.7. The content deploy playbook, where Jenkins uses
this Docker image, is already compatible.

Optimized the build instructions for a smaller image size, as per
recommendations at https://www.fromlatest.io/

This is for https://phabricator.wikimedia.org/T212858